### PR TITLE
Add retrying/failed statuses

### DIFF
--- a/backend/app/db/crud.py
+++ b/backend/app/db/crud.py
@@ -1269,7 +1269,11 @@ async def get_dashboard_stats(current_user_payload: Dict[str, Any]) -> Dict[str,
         logger.debug(f"[Stats] Flagged recent query result: {flagged_recent}")
 
         # Pending/Processing Documents (based on Document status)
-        pending_statuses = [DocumentStatus.QUEUED.value, DocumentStatus.PROCESSING.value]
+        pending_statuses = [
+            DocumentStatus.QUEUED.value,
+            DocumentStatus.PROCESSING.value,
+            DocumentStatus.RETRYING.value,
+        ]
         pending = await docs_collection.count_documents({"teacher_id": teacher_kinde_id, "status": {"$in": pending_statuses}})
         logger.debug(f"[Stats] Pending query result: {pending}")
 

--- a/backend/app/models/enums.py
+++ b/backend/app/models/enums.py
@@ -40,6 +40,8 @@ class DocumentStatus(str, Enum):
     PROCESSING = "PROCESSING" # Actively being analyzed by ML model (Changed to uppercase)
     COMPLETED = "COMPLETED"   # Analysis finished, result available (Changed to uppercase)
     ERROR = "ERROR"           # An error occurred during processing (Changed to uppercase)
+    RETRYING = "RETRYING"     # Document processing is being retried
+    FAILED = "FAILED"         # Processing failed after retries
 
 # --- Result Related Enums ---
 
@@ -49,6 +51,8 @@ class ResultStatus(str, Enum):
     ASSESSING = "ASSESSING"   # Analysis in progress (Changed to uppercase)
     COMPLETED = "COMPLETED"   # Analysis complete, score available (Changed to uppercase)
     ERROR = "ERROR"           # Error during analysis, score may be unavailable (Changed to uppercase)
+    RETRYING = "RETRYING"     # Analysis is being retried after a failure
+    FAILED = "FAILED"         # Analysis failed after retries
 
 class BatchStatus(str, Enum):
     """Enumeration for the status of a document batch upload."""


### PR DESCRIPTION
## Summary
- extend `DocumentStatus` and `ResultStatus` with `RETRYING` and `FAILED`
- allow trigger/cancel logic to recognise new states
- include RETRYING docs in dashboard pending count

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*